### PR TITLE
Rouge's Formatter Options

### DIFF
--- a/doc_repo.gemspec
+++ b/doc_repo.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '~> 2.0'
 
-  spec.add_dependency "rouge", "~> 1.6"
-  spec.add_dependency "redcarpet", "~> 3.1"
+  spec.add_dependency "rouge", "~> 1.8"
+  spec.add_dependency "redcarpet", "~> 3.2"
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/doc_repo/converters/markdown_parser.rb
+++ b/lib/doc_repo/converters/markdown_parser.rb
@@ -27,9 +27,10 @@ module DocRepo
 
       protected
 
-        def rouge_formatter(opts = {})
-          Rouge::Formatters::HTML.new(opts.merge(wrap: false))
+        def rouge_formatter(lexer)
+          Rouge::Formatters::HTML.new(wrap: false)
         end
+
       end
 
       def initialize(config)

--- a/lib/doc_repo/version.rb
+++ b/lib/doc_repo/version.rb
@@ -1,3 +1,3 @@
 module DocRepo
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
Rouge's RedCarpet API had changed and was causing an exception when initializing the formatter. This change was the minimal update needed to make the rendering work.

See for more:
- jekyll/jekyll@e6f8907
- jneen/rouge@18ec938
- jneen/rouge#182