### PR TITLE
Use the file extension if it is provided

### DIFF
--- a/lib/doc_repo/page.rb
+++ b/lib/doc_repo/page.rb
@@ -5,7 +5,15 @@ module DocRepo
     attr_accessor :body
 
     def initialize(file)
-      @body = GithubFile.new("#{file}.md").read_remote_file
+      @body = GithubFile.new(default_ext(file)).read_remote_file
+    end
+
+    def default_ext(file)
+      if File.extname(file).empty?
+        "#{file}.md"
+      else
+        file
+      end
     end
 
     def to_html

--- a/spec/doc_repo/page_spec.rb
+++ b/spec/doc_repo/page_spec.rb
@@ -10,21 +10,35 @@ RSpec.describe DocRepo::Page do
     end
   end
 
-  it "returns the markdown as html" do
-    body = <<-END.strip_heredoc
+  let(:body){
+    <<-END.strip_heredoc
       # A heading
 
       Some content
     END
+  }
 
+  let(:rendered_html){
+    <<-END.strip_heredoc
+      <h1 id=\"a-heading\">A heading</h1>
+
+      <p>Some content</p>
+    END
+  }
+
+  it "returns the markdown as html when there is no extension" do
     stub_request(:get, "https://api.github.com/repos/RadiusNetworks/doc_spec/contents/docs/page.md?ref=master")
       .to_return(body: body)
 
     page = DocRepo::Page.new("page")
-    expect(page.to_html).to eq <<-END.strip_heredoc
-        <h1 id=\"a-heading\">A heading</h1>
+    expect(page.to_html).to eq rendered_html
+  end
 
-        <p>Some content</p>
-    END
+  it "returns the markdown as html when there is a .md extension" do
+    stub_request(:get, "https://api.github.com/repos/RadiusNetworks/doc_spec/contents/docs/page.md?ref=master")
+      .to_return(body: body)
+
+    page = DocRepo::Page.new("page.md")
+    expect(page.to_html).to eq rendered_html
   end
 end


### PR DESCRIPTION
If the slug provided has an extension try to fetch that resource from Github and render it. If there is no extension add a `.md` and try to fetch that.

When all else fails render a 404.

This lets us link to files the same way in the app as on github.

`/ios` would pull up the file from `docs/ios.md`

But that wouldn't work when linking between markdown files, since the first url would be a 404 when browsing the repo. So to fix that, allow linking to files ending in `.md`:

`/ios.md` would pull up the file from `docs/ios.md`
