### PR TITLE
Use Github raw domain as content source

### DIFF
--- a/lib/doc_repo.rb
+++ b/lib/doc_repo.rb
@@ -17,11 +17,14 @@ module DocRepo
   end
 
   class << self
-    attr_accessor :configuration
+    attr_reader :configuration
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
   end
 
   def self.configure
-    self.configuration ||= Configuration.new
     yield(configuration) if block_given?
   end
 

--- a/lib/doc_repo/github_file.rb
+++ b/lib/doc_repo/github_file.rb
@@ -3,7 +3,7 @@ require 'open-uri'
 module DocRepo
   class GithubFile
 
-    attr_reader :org, :repo, :branch, :file
+    attr_reader :org, :repo, :branch, :file, :raw_url
     def initialize(file,
                    org: DocRepo.configuration.org,
                    repo: DocRepo.configuration.repo,
@@ -12,14 +12,13 @@ module DocRepo
       @org = org
       @repo = repo
       @branch = branch
+      @raw_url = url(file)
     end
 
-    def redirect_url
-      "https://github.com/#{org}/#{repo}/raw/#{branch}/docs/#{file}"
-    end
+    alias_method :redirect_url, :raw_url
 
     def read_remote_file
-      open(url(file), headers).read
+      open(raw_url, headers).read
     rescue OpenURI::HTTPError => http_error
       raise DocRepo::NotFound.new(base: http_error)
     end
@@ -38,7 +37,7 @@ module DocRepo
     end
 
     def url(file)
-      "https://api.github.com/repos/#{org}/#{repo}/contents/docs/#{file}?ref=#{branch}"
+      "https://raw.githubusercontent.com/#{org}/#{repo}/#{branch}/docs/#{file}"
     end
   end
 end

--- a/spec/doc_repo/page_spec.rb
+++ b/spec/doc_repo/page_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe DocRepo::Page do
   }
 
   it "returns the markdown as html when there is no extension" do
-    stub_request(:get, "https://api.github.com/repos/RadiusNetworks/doc_spec/contents/docs/page.md?ref=master")
+    stub_request(:get, "https://raw.githubusercontent.com/RadiusNetworks/doc_spec/master/docs/page.md")
       .to_return(body: body)
 
     page = DocRepo::Page.new("page")
@@ -35,7 +35,7 @@ RSpec.describe DocRepo::Page do
   end
 
   it "returns the markdown as html when there is a .md extension" do
-    stub_request(:get, "https://api.github.com/repos/RadiusNetworks/doc_spec/contents/docs/page.md?ref=master")
+    stub_request(:get, "https://raw.githubusercontent.com/RadiusNetworks/doc_spec/master/docs/page.md")
       .to_return(body: body)
 
     page = DocRepo::Page.new("page.md")

--- a/spec/doc_repo/repository_spec.rb
+++ b/spec/doc_repo/repository_spec.rb
@@ -16,9 +16,10 @@ RSpec.describe DocRepo::Repository do
 
     repo.respond("sonic_screwdriver.png") do |r|
       r.redirect do |url|
-        expect( url ).to match %r{.*raw/master/docs/sonic_screwdriver.png}
+        expect( url ).to match %r{https://raw\..*/master/docs/sonic_screwdriver.png}
       end
     end
   end
+
 end
 


### PR DESCRIPTION
The domain `raw.githubusercontent.com` does not impose rate limits. In fact using the regular `github.com` domain to access a static asset (like a PNG) using `cURL` redirects to this raw domain:

```shell
curl -Is "https://github.com/{ORG}/{REPO}/raw/{BRANCH}/docs/image.png"
```
```http
HTTP/1.1 302 Found
Server: GitHub.com
Date: Thu, 22 Jun 2017 18:31:55 GMT
Content-Type: text/html; charset=utf-8
Status: 302 Found
Cache-Control: no-cache
Vary: X-PJAX, Accept-Encoding
X-RateLimit-Limit: 100
X-RateLimit-Remaining: 100
Access-Control-Allow-Origin: https://render.githubusercontent.com
Location: https://raw.githubusercontent.com/ORG/REPO/BRANCH/docs/image.png
X-UA-Compatible: IE=Edge,chrome=1
X-Runtime: 0.017536
Strict-Transport-Security: max-age=31536000; includeSubdomains; preload
X-Content-Type-Options: nosniff
X-Frame-Options: deny
X-XSS-Protection: 1; mode=block
X-Runtime-rack: 0.020754
X-Served-By: 7d2a2d05162492046d9960cdbc326796
Age: 0
X-GitHub-Request-Id: D5DB:4C9C:2CFB8EA:4161CAD:594C0D1B
```

When we request the raw domain content:

```shell
curl -Is "https://raw.githubusercontent.com/ORG/REPO/BRANCH/docs/image.png"
```
```http
HTTP/1.1 200 OK
Content-Security-Policy: default-src 'none'; style-src 'unsafe-inline'
Strict-Transport-Security: max-age=31536000
X-Content-Type-Options: nosniff
X-Frame-Options: deny
X-XSS-Protection: 1; mode=block
ETag: "fd51ed6a84d1ee36c3b0af994dea8c32c785bb29"
Content-Type: image/png
Cache-Control: max-age=300
X-Geo-Block-List:
X-GitHub-Request-Id: AB1E:1776:F1BF31:F95F97:594C0D02
Content-Length: 18411
Accept-Ranges: bytes
Date: Thu, 22 Jun 2017 18:34:09 GMT
Via: 1.1 varnish
Connection: keep-alive
X-Served-By: cache-iad2125-IAD
X-Cache: HIT
X-Cache-Hits: 1
X-Timer: S1498156449.322911,VS0,VE1
Vary: Authorization,Accept-Encoding
Access-Control-Allow-Origin: *
X-Fastly-Request-ID: a440cac380cd0e67b5ebdc40c5d8a4185be58bf1
Expires: Thu, 22 Jun 2017 18:39:09 GMT
Source-Age: 159
```

Per these HTTP responses we can see there is no rate limit imposed. As we are only targeting public repos it makes sense to switch all our URLs to this domain.

This starts work related to #6 and is a non-breaking change we can implement today.